### PR TITLE
use base image from public ECR instead of DockerHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM python:3.9.15-slim as req
+FROM public.ecr.aws/docker/library/python:3.9.15-slim as req
 COPY pyproject.toml .
 COPY poetry.lock .
 RUN pip install poetry && poetry export --without-hashes -o requirements.txt
 
-FROM python:3.9.15-slim as builder
+FROM public.ecr.aws/docker/library/python:3.9.15-slim as builder
 # install building necessities here with apt-get install, e.g. apt-get update && apt-get install gcc (if needed)
 COPY --from=req requirements.txt .
 RUN pip install --user -r requirements.txt
 
-FROM python:3.9.15-slim as runner
+FROM public.ecr.aws/docker/library/python:3.9.15-slim as runner
 # install running necessities here with apt-get install, e.g. apt-get update && apt-get install libpq-dev (if needed)
 COPY --from=builder /root/.local /root/.local
 COPY . /ata-pipeline0/


### PR DESCRIPTION
Use the same base image as before but the one hosted on public ECR so we don't get rate limited; this might change moving forward (to use a lambda specific image, for example) but just want to prove that the CD works first.

Got a "toomanyrequests" error from a single request when trying to build: https://www.docker.com/increase-rate-limits/