### PR TITLE
Dummy lambda handler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,22 @@ COPY poetry.lock .
 RUN pip install poetry && poetry export --without-hashes -o requirements.txt
 
 FROM python:3.9.15-slim as builder
-# install building necessities here with apt-get install, e.g. apt-get update && apt-get install gcc (if needed)
+# Install aws-lambda-cpp build dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  g++ \
+  make \
+  cmake \
+  unzip \
+  libcurl4-openssl-dev
 COPY --from=req requirements.txt .
-RUN pip install --user -r requirements.txt
+RUN pip install --user -r requirements.txt awslambdaric==2.0.4
 
 FROM python:3.9.15-slim as runner
 # install running necessities here with apt-get install, e.g. apt-get update && apt-get install libpq-dev (if needed)
 COPY --from=builder /root/.local /root/.local
 COPY . /ata-pipeline0/
 ENV PATH=/root/.local/bin:$PATH
+WORKDIR /ata-pipeline0/src
+ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
+CMD [ "main.handler" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,9 @@ COPY pyproject.toml .
 COPY poetry.lock .
 RUN pip install poetry && poetry export --without-hashes -o requirements.txt
 
-FROM public.ecr.aws/docker/library/python:3.9.15-slim as builder
-# Install aws-lambda-cpp build dependencies
-RUN apt-get update && \
-  apt-get install -y \
-  g++ \
-  make \
-  cmake \
-  unzip \
-  libcurl4-openssl-dev
-COPY --from=req requirements.txt .
-RUN pip install --user -r requirements.txt awslambdaric==2.0.4
-
-FROM public.ecr.aws/docker/library/python:3.9.15-slim as runner
-# install running necessities here with apt-get install, e.g. apt-get update && apt-get install libpq-dev (if needed)
-COPY --from=builder /root/.local /root/.local
-COPY . /ata-pipeline0/
-ENV PATH=/root/.local/bin:$PATH
-WORKDIR /ata-pipeline0/src
-ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
-CMD [ "main.handler" ]
+FROM public.ecr.aws/lambda/python:3.9 as runner
+COPY --from=req requirements.txt  .
+RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+COPY /src/ ${LAMBDA_TASK_ROOT}/src
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "src/main.handler" ]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
 # ata-pipeline0
 Snowplow to Redshift data processing.
 
-## Use
-TODO, don't have a main path to execute yet.
+## Run
+
+Since this code is containerized to run on Lambda, the main entrypoint isn't quite designed to run locally.
+However, we can build the Docker image and run it locally, then ping it to try it out locally. We can, of course,
+still test all the functions used by the main handler and run those separately (e.g. in a scratch file) if so desired.
+
+### Docker
+
+The `Dockerfile` in the root of the project is the correct target for building.
+
+To build locally: `docker build -t {desired-name-and-tag} .`. For example: `docker build -t lnl/ata-p0:latest .`
+Don't forget the `.` at the end to reference the `Dockerfile` in the current directory (assuming you run the command
+from the root of the project).
+
+To run the Docker image locally (with the Lambda set up):
+`docker run --rm -p {local_port}:{container_port} {name-and-tag} {command}`.
+For example: `docker run --rm -p 9000:8080 lnl/ata-p0:latest`. This will serve it on `localhost:9000`. To ping
+the handler (and confirm it works), you can then make an HTTP request to it. For example:
+`curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{"field1":"b", "field2":"a"}'`
 
 ## Development Tools
 
@@ -49,16 +66,3 @@ We run continuous integration (CI) via GitHub actions. We have actions to run My
 
 Deployment for the Local News Lab (LNL) is handled via AWS CodePipeline, defined elsewhere in the ata-infrastructure repo.
 We use Docker to containerize our code. The LNL deploys this project on AWS Lambda.
-
-### Docker
-
-The `Dockerfile` in the root of the project is the correct target for building.
-
-To build locally: `docker build -t {desired-name-and-tag} .`. For example: `docker build -t lnl/ata-p0:latest .`
-Don't forget the `.` at the end to reference the `Dockerfile` in the current directory (assuming you run the command
-from the root of the project).
-
-To run the Docker image locally: `docker run -it --rm {name-and-tag} {command}`. For example: `docker run -it --rm
-lnl/ata-p0:latest bash`
-
-Note that the code is structured so that you can run it either as a Docker container or directly on your machine/IDE.

--- a/poetry.lock
+++ b/poetry.lock
@@ -14,14 +14,14 @@ tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy 
 
 [[package]]
 name = "boto3"
-version = "1.26.1"
+version = "1.26.3"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = ">=1.29.1,<1.30.0"
+botocore = ">=1.29.3,<1.30.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -30,8 +30,8 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.26.1"
-description = "Type annotations for boto3 1.26.1 generated with mypy-boto3-builder 7.11.10"
+version = "1.26.3"
+description = "Type annotations for boto3 1.26.3 generated with mypy-boto3-builder 7.11.10"
 category = "main"
 optional = false
 python-versions = ">=3.7"
@@ -366,7 +366,7 @@ xray = ["mypy-boto3-xray (>=1.26.0,<1.27.0)"]
 
 [[package]]
 name = "botocore"
-version = "1.29.1"
+version = "1.29.3"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -382,7 +382,7 @@ crt = ["awscrt (==0.14.0)"]
 
 [[package]]
 name = "botocore-stubs"
-version = "1.29.1"
+version = "1.29.3"
 description = "Type annotations and code completion for botocore"
 category = "main"
 optional = false
@@ -670,7 +670,7 @@ crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
 name = "setuptools"
-version = "65.5.0"
+version = "65.5.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
@@ -678,7 +678,7 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -778,20 +778,20 @@ attrs = [
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
 boto3 = [
-    {file = "boto3-1.26.1-py3-none-any.whl", hash = "sha256:3b0fa19390895e664045713f2e47e63ad29c9f98b7bee6836dec7124953e48b8"},
-    {file = "boto3-1.26.1.tar.gz", hash = "sha256:9feb98e045736f943c2099d955415cfe44133e03d8e2d7581d2e5dc74d0ed064"},
+    {file = "boto3-1.26.3-py3-none-any.whl", hash = "sha256:7e871c481f88e5b2fc6ac16eb190c95de21efb43ab2d959beacf8b7b096b11d2"},
+    {file = "boto3-1.26.3.tar.gz", hash = "sha256:b81e4aa16891eac7532ce6cc9eb690a8d2e0ceea3bcf44b5c5a1309c2500d35f"},
 ]
 boto3-stubs = [
-    {file = "boto3-stubs-1.26.1.tar.gz", hash = "sha256:456fe888c908d85ae157abaeffc2ac73d4e9d0085fb7ee29008b12ce2185f21e"},
-    {file = "boto3_stubs-1.26.1-py3-none-any.whl", hash = "sha256:2dde0a86724d7465aad9b82eb59c7c696bfdbea72efeb4de23407b1474cdaba4"},
+    {file = "boto3-stubs-1.26.3.tar.gz", hash = "sha256:8e10c633fed8137a57348a5789c27b6182559a7e9d418ee8a98736e7581a6632"},
+    {file = "boto3_stubs-1.26.3-py3-none-any.whl", hash = "sha256:01c2822b375cac99c3d2de046035c4b4ee6bd363e6fa88b5aecc2ab1d52f164b"},
 ]
 botocore = [
-    {file = "botocore-1.29.1-py3-none-any.whl", hash = "sha256:75c65130ffab527d0a3d948c6d87eb8eac210e079e1ff2768c66484be57bb77c"},
-    {file = "botocore-1.29.1.tar.gz", hash = "sha256:e38b7cdce927cefabe45608dde61660b76458fba6624240dcdb6c4b8453d17f7"},
+    {file = "botocore-1.29.3-py3-none-any.whl", hash = "sha256:100534532b2745f6fa019b79199a8941f04b8168f9d557d0847191455f1f1eed"},
+    {file = "botocore-1.29.3.tar.gz", hash = "sha256:ac7986fefe1b9c6323d381c4fdee3845c67fa53eb6c9cf586a8e8a07270dbcfe"},
 ]
 botocore-stubs = [
-    {file = "botocore_stubs-1.29.1-py3-none-any.whl", hash = "sha256:897880dc73340a5384b2979e0612a0126e7f4619450688cc24d0b1f08f71da02"},
-    {file = "botocore_stubs-1.29.1.tar.gz", hash = "sha256:2ccda5c8527a33f0a0fcd3e75f3c4c09c89eac913cf8793373c5977415752565"},
+    {file = "botocore_stubs-1.29.3-py3-none-any.whl", hash = "sha256:32254b6676a3ec460a30d492b055d124d184ad1041c2c99fbb447231ad90e97e"},
+    {file = "botocore_stubs-1.29.3.tar.gz", hash = "sha256:9477268235d9927a2b22c1aa23c412a8454851d68dbbc49854ad2291d4bba159"},
 ]
 cfgv = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
@@ -1005,8 +1005,8 @@ s3transfer = [
     {file = "s3transfer-0.6.0.tar.gz", hash = "sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947"},
 ]
 setuptools = [
-    {file = "setuptools-65.5.0-py3-none-any.whl", hash = "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"},
-    {file = "setuptools-65.5.0.tar.gz", hash = "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17"},
+    {file = "setuptools-65.5.1-py3-none-any.whl", hash = "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31"},
+    {file = "setuptools-65.5.1.tar.gz", hash = "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,6 @@
-def my_fn(x: int, y: int) -> int:
-    return x + y
+import json
 
 
-if __name__ == "__main__":
-    a = 2
-    b = 3
-    print(f"Hello, World! The sum of {a} and {b} is {my_fn(a, b)}")
+def handler(event, context):
+    # Note: this is invoked by an event-driven, async method (s3 trigger) so the return value is discarded
+    print("request: {}".format(json.dumps(event)))

--- a/src/main.py
+++ b/src/main.py
@@ -4,3 +4,4 @@ import json
 def handler(event, context):
     # Note: this is invoked by an event-driven, async method (s3 trigger) so the return value is discarded
     print("request: {}".format(json.dumps(event)))
+    return {"hi": "there"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,2 @@
-from src.main import my_fn
-
-
-def test_my_fn():
-    # confirm that my_fn simply sums two integers
-    out = my_fn(1, 2)
-    assert out == 3
+def test_handler():
+    pass


### PR DESCRIPTION
- Update Dockerfile to be compatible with AWS lambda
- Update `main.py` to have a simple dummy handler function
- Include instructions in the readme to run this locally

Need to make these changes so that we can actually confirm the Lambda works as expected. Unfortunately this increases the image size, but the path of least resistance seems to be to use the AWS lambda python image.