### PR TITLE
Add site-name preprocessor

### DIFF
--- a/src/fetch_events.py
+++ b/src/fetch_events.py
@@ -10,12 +10,13 @@ from mypy_boto3_s3.service_resource import ObjectSummary, S3ServiceResource
 from mypy_boto3_s3.type_defs import GetObjectOutputTypeDef
 
 from src.helpers.logging import logging
+from src.helpers.site import SiteName
 
 logger = logging.getLogger(__name__)
 
 
 def fetch_events(
-    s3_resource: S3ServiceResource, site_bucket_name: str, timestamps: List[datetime], num_concurrent_downloads: int
+    s3_resource: S3ServiceResource, site_name: SiteName, timestamps: List[datetime], num_concurrent_downloads: int
 ) -> pd.DataFrame:
     """
     Given config inputs, including a site's bucket name and a list of date-hour
@@ -27,7 +28,7 @@ def fetch_events(
     >>> s3_resource = boto3.resource("s3")
     """
     # Grab S3 bucket
-    bucket = s3_resource.Bucket(site_bucket_name)
+    bucket = s3_resource.Bucket(f"lnl-snowplow-{site_name}")
 
     # Get a list of summaries of S3 objects to fetch
     object_summaries_by_timestamp = [

--- a/src/helpers/fields.py
+++ b/src/helpers/fields.py
@@ -70,3 +70,12 @@ class FieldSnowplow(str, Enum):
 
     # [STR] Raw useragent
     USERAGENT = "useragent"
+
+
+class FieldNew(str, Enum):
+    """
+    Enum for non-Snowplow fields to be added.
+    """
+
+    # [STR] Site partner's name (as a slug corresponding to its S3 bucket)
+    SITE_NAME = "site_name"

--- a/src/helpers/fields.py
+++ b/src/helpers/fields.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class Field(str, Enum):
+class FieldSnowplow(str, Enum):
     """
     Enum for Snowplow fields of interest.
     Snowplow documentation of these fields can be found here: https://docs.snowplow.io/docs/understanding-your-pipeline/canonical-event/.

--- a/src/helpers/preprocessors.py
+++ b/src/helpers/preprocessors.py
@@ -4,8 +4,9 @@ from typing import Set
 
 import pandas as pd
 
-from src.helpers.fields import FieldSnowplow
+from src.helpers.fields import FieldNew, FieldSnowplow
 from src.helpers.logging import logging
+from src.helpers.site import SiteName
 
 logger = logging.getLogger(__name__)
 
@@ -134,3 +135,25 @@ class ConvertFieldTypes(Preprocessor):
 
     def log_result(self, df_in=None, df_out=None) -> None:
         logger.info("Converted field data types")
+
+
+@dataclass
+class AddFieldSiteName(Preprocessor):
+    """
+    Adds a constant field holding partner's name to the Snowplow events DataFrame.
+    """
+
+    site_name: SiteName
+    field_site_name: FieldNew
+
+    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
+        # Make a copy of the original so that it's not affected, but can remove
+        # this if memory is an issue
+        df = df.copy()
+
+        df[self.field_site_name] = self.site_name
+
+        return df
+
+    def log_result(self, df_in=None, df_out=None) -> None:
+        logger.info(f"Added site name {self.site_name} as a new field")

--- a/src/helpers/preprocessors.py
+++ b/src/helpers/preprocessors.py
@@ -4,7 +4,7 @@ from typing import Set
 
 import pandas as pd
 
-from src.helpers.fields import Field
+from src.helpers.fields import FieldSnowplow
 from src.helpers.logging import logging
 
 logger = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ class SelectFieldsRelevant(Preprocessor):
     it'll be added to the result DataFrame as an empty column.
     """
 
-    fields_relevant: Set[Field]
+    fields_relevant: Set[FieldSnowplow]
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
         # Sometimes, df doesn't have all the fields in fields_relevant, so we create
@@ -73,7 +73,7 @@ class DeleteRowsEmpty(Preprocessor):
     with null values in any of these fields.
     """
 
-    fields_required: Set[Field]
+    fields_required: Set[FieldSnowplow]
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
         return df.dropna(subset=[*self.fields_required])
@@ -90,7 +90,7 @@ class DeleteRowsDuplicateKey(Preprocessor):
     Delete all rows whose primary key is repeated in the DataFrame.
     """
 
-    field_primary_key: Field
+    field_primary_key: FieldSnowplow
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
         return df.drop_duplicates(subset=[self.field_primary_key], keep=False)
@@ -108,10 +108,10 @@ class ConvertFieldTypes(Preprocessor):
     Changes data types in a Snowplow events DataFrame to those desired.
     """
 
-    fields_int: Set[Field]
-    fields_float: Set[Field]
-    fields_datetime: Set[Field]
-    fields_categorical: Set[Field]
+    fields_int: Set[FieldSnowplow]
+    fields_float: Set[FieldSnowplow]
+    fields_datetime: Set[FieldSnowplow]
+    fields_categorical: Set[FieldSnowplow]
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
         # Make a copy of the original so that it's not affected, but can remove

--- a/src/helpers/site.py
+++ b/src/helpers/site.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class SiteName(str, Enum):
+    """
+    Enum of partner slugs corresponding to the S3 buckets
+    """
+
+    AFRO_LA = "afro-la"
+    DALLAS_FREE_PRESS = "dallas-free-press"
+    OPEN_VALLEJO = "open-vallejo"
+    THE_19TH = "the-19th"

--- a/tests/test_preprocess_events.py
+++ b/tests/test_preprocess_events.py
@@ -9,7 +9,7 @@ from pandas.api.types import (
     is_int64_dtype,
 )
 
-from src.helpers.fields import Field
+from src.helpers.fields import FieldSnowplow
 from src.helpers.preprocessors import (
     ConvertFieldTypes,
     DeleteRowsDuplicateKey,
@@ -33,51 +33,51 @@ def df() -> pd.DataFrame:
             ["C2", "1", "1500", "400", None, None],
         ],
         columns=[
-            Field.EVENT_ID,
-            Field.DOMAIN_SESSIONIDX,
-            Field.DOC_HEIGHT,
-            Field.PP_YOFFSET_MAX,
-            Field.DERIVED_TSTAMP,
-            Field.EVENT_NAME,
+            FieldSnowplow.EVENT_ID,
+            FieldSnowplow.DOMAIN_SESSIONIDX,
+            FieldSnowplow.DOC_HEIGHT,
+            FieldSnowplow.PP_YOFFSET_MAX,
+            FieldSnowplow.DERIVED_TSTAMP,
+            FieldSnowplow.EVENT_NAME,
         ],
     )
 
 
 @pytest.fixture(scope="module")
-def fields_relevant() -> Set[Field]:
-    return {Field.EVENT_ID, Field.DERIVED_TSTAMP, Field.PAGE_URLPATH}
+def fields_relevant() -> Set[FieldSnowplow]:
+    return {FieldSnowplow.EVENT_ID, FieldSnowplow.DERIVED_TSTAMP, FieldSnowplow.PAGE_URLPATH}
 
 
 @pytest.fixture(scope="module")
-def fields_required() -> Set[Field]:
-    # Field.Event_NAME isn't included in the dummy DataFrame, but it should
+def fields_required() -> Set[FieldSnowplow]:
+    # FieldSnowplow.Event_NAME isn't included in the dummy DataFrame, but it should
     # still be included in the output DataFrame as an empty column
-    return {Field.EVENT_ID, Field.DOC_HEIGHT, Field.DERIVED_TSTAMP, Field.EVENT_NAME}
+    return {FieldSnowplow.EVENT_ID, FieldSnowplow.DOC_HEIGHT, FieldSnowplow.DERIVED_TSTAMP, FieldSnowplow.EVENT_NAME}
 
 
 @pytest.fixture(scope="module")
-def field_primary_key() -> Field:
-    return Field.EVENT_ID
+def field_primary_key() -> FieldSnowplow:
+    return FieldSnowplow.EVENT_ID
 
 
 @pytest.fixture(scope="module")
-def fields_int() -> Set[Field]:
-    return {Field.DOMAIN_SESSIONIDX}
+def fields_int() -> Set[FieldSnowplow]:
+    return {FieldSnowplow.DOMAIN_SESSIONIDX}
 
 
 @pytest.fixture(scope="module")
-def fields_float() -> Set[Field]:
-    return {Field.DOC_HEIGHT, Field.PP_YOFFSET_MAX}
+def fields_float() -> Set[FieldSnowplow]:
+    return {FieldSnowplow.DOC_HEIGHT, FieldSnowplow.PP_YOFFSET_MAX}
 
 
 @pytest.fixture(scope="module")
-def fields_datetime() -> Set[Field]:
-    return {Field.DERIVED_TSTAMP}
+def fields_datetime() -> Set[FieldSnowplow]:
+    return {FieldSnowplow.DERIVED_TSTAMP}
 
 
 @pytest.fixture(scope="module")
-def fields_categorical() -> Set[Field]:
-    return {Field.EVENT_NAME}
+def fields_categorical() -> Set[FieldSnowplow]:
+    return {FieldSnowplow.EVENT_NAME}
 
 
 # ---------- TESTS ----------

--- a/tests/test_preprocess_events.py
+++ b/tests/test_preprocess_events.py
@@ -133,4 +133,5 @@ def test_convert_field_types(df, fields_int, fields_float, fields_datetime, fiel
 
 def test_add_field_site_name(df, site_name, field_site_name) -> None:
     df = AddFieldSiteName(site_name, field_site_name)(df)
+    # pd.Series.all returns True if all of its boolean values are True
     assert (df[field_site_name] == site_name).all()


### PR DESCRIPTION
## Description

This PR adds a new preprocessor, `AddFieldSiteName`, which adds a new column to the staged DataFrame indicating the partner name.

Other notable changes include renaming the `Field` enum into `FieldSnowplow` to differentiate it from the new `FieldNew` enum, which stores names of fields not present in the raw Snowplow data (i.e., fields added by us).

## Testing

This PR also adds a new unit test for the new preprocessor & cleans up other tests & fixture just a little. All tests passed.