### PR TITLE
Have key-deduping preprocessor keep earliest event

### DIFF
--- a/src/helpers/preprocessors.py
+++ b/src/helpers/preprocessors.py
@@ -92,9 +92,14 @@ class DeleteRowsDuplicateKey(Preprocessor):
     """
 
     field_primary_key: FieldSnowplow
+    field_timestamp: FieldSnowplow
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
-        return df.drop_duplicates(subset=[self.field_primary_key], keep=False)
+        # Sort values by timestamp so the first event kept is the earliest,
+        # which is most likely to be a parent (if its key doesn't already exist
+        # in the DB)
+        df = df.sort_values(self.field_timestamp)
+        return df.drop_duplicates(subset=[self.field_primary_key], keep="first")
 
     def log_result(self, df_in: pd.DataFrame, df_out: pd.DataFrame) -> None:
         logger.info(

--- a/src/helpers/preprocessors.py
+++ b/src/helpers/preprocessors.py
@@ -98,6 +98,7 @@ class DeleteRowsDuplicateKey(Preprocessor):
         # Sort values by timestamp so the first event kept is the earliest,
         # which is most likely to be a parent (if its key doesn't already exist
         # in the DB)
+        # (see: https://snowplow.io/blog/dealing-with-duplicate-event-ids/)
         df = df.sort_values(self.field_timestamp)
         return df.drop_duplicates(subset=[self.field_primary_key], keep="first")
 

--- a/src/main.py
+++ b/src/main.py
@@ -62,6 +62,7 @@ def run_pipeline(site_name: SiteName, timestamps: List[datetime], concurrency: i
                 fields_datetime={FieldSnowplow.DERIVED_TSTAMP},
                 fields_categorical={FieldSnowplow.EVENT_NAME, FieldSnowplow.REFR_MEDIUM, FieldSnowplow.REFR_SOURCE},
             ),
+            # This happens after converting field type because timestamps need to be in datetime format
             DeleteRowsDuplicateKey(
                 field_primary_key=FieldSnowplow.EVENT_ID, field_timestamp=FieldSnowplow.DERIVED_TSTAMP
             ),

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,6 @@ def run_pipeline(site_name: SiteName, timestamps: List[datetime], concurrency: i
         df,
         preprocessors=[
             SelectFieldsRelevant(fields_relevant={*FieldSnowplow}),
-            DeleteRowsDuplicateKey(field_primary_key=FieldSnowplow.EVENT_ID),
             DeleteRowsEmpty(
                 fields_required={
                     FieldSnowplow.DERIVED_TSTAMP,
@@ -62,6 +61,9 @@ def run_pipeline(site_name: SiteName, timestamps: List[datetime], concurrency: i
                 },
                 fields_datetime={FieldSnowplow.DERIVED_TSTAMP},
                 fields_categorical={FieldSnowplow.EVENT_NAME, FieldSnowplow.REFR_MEDIUM, FieldSnowplow.REFR_SOURCE},
+            ),
+            DeleteRowsDuplicateKey(
+                field_primary_key=FieldSnowplow.EVENT_ID, field_timestamp=FieldSnowplow.DERIVED_TSTAMP
             ),
             AddFieldSiteName(site_name, field_site_name=FieldNew.SITE_NAME),
         ],


### PR DESCRIPTION
## Description

We currently throw out _all_ events associated with a duplicate `event_id` during staging. This PR changes appropriate preprocessor so that the earliest-occuring one is kept, since that has the greatest chance of being an actual event (a.k.a., [the parent](https://snowplow.io/blog/dealing-with-duplicate-event-ids/) of the duplications that come after it). If the kept event's composite key already exists in the DB, `on_conflict_do_nothing` will still not write it to the DB as usual, but if the key doesn't, the event will be written.

## Testing

The appropriate unit test was modified. All tests passed.