### PR TITLE
edit dockerfile to install desired postgres dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ COPY poetry.lock .
 RUN pip install poetry && poetry export --without-hashes -o requirements.txt
 
 FROM public.ecr.aws/lambda/python:3.9 as runner
-COPY --from=req requirements.txt  .
-RUN yum update -y && yum install postgresql-devel gcc -y
-RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+COPY --from=req requirements.txt .
+RUN yum update -y && yum install amazon-linux-extras postgresql-devel gcc -y
+RUN PYTHON=python2 amazon-linux-extras install postgresql11
+RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 COPY /ata_pipeline0/ ${LAMBDA_TASK_ROOT}/ata_pipeline0
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 CMD [ "ata_pipeline0/main.handler" ]


### PR DESCRIPTION
Getting a version-related error when running this on AWS lambda:

`OperationalError: (psycopg2.OperationalError) SCRAM authentication requires libpq version 10 or above`

This change should result in a libpq bersion of at least 10, which should address this issue.