### PR TITLE
[change] rename Event enum to EventName & use this enum where applicable

### DIFF
--- a/ata_pipeline0/helpers/events.py
+++ b/ata_pipeline0/helpers/events.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class Event(str, Enum):
+class EventName(str, Enum):
     """
     Enum for Snowplow event names.
     """

--- a/ata_pipeline0/helpers/preprocessors.py
+++ b/ata_pipeline0/helpers/preprocessors.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import user_agents as ua
 
-from ata_pipeline0.helpers.events import Event
+from ata_pipeline0.helpers.events import EventName
 from ata_pipeline0.helpers.fields import FieldNew, FieldSnowplow
 from ata_pipeline0.helpers.logging import logging
 from ata_pipeline0.site.names import SiteName
@@ -72,7 +72,7 @@ class AddFieldFormSubmitIsNewsletter(Preprocessor):
     def _is_newsletter_signup(self, event: pd.Series) -> Union[float, bool]:
         # Return np.nan if event is not a form-submission event
         # (can't return None because it'll throw off mypy, will convert later into None)
-        if event[self.field_event_name] != Event.SUBMIT_FORM:
+        if event[self.field_event_name] != EventName.SUBMIT_FORM:
             return np.nan
 
         return self.site_newsletter_signup_validator.validate(event)

--- a/tests/helpers/test_preprocessors.py
+++ b/tests/helpers/test_preprocessors.py
@@ -11,6 +11,7 @@ from pandas.api.types import (
     is_int64_dtype,
 )
 
+from ata_pipeline0.helpers.events import EventName
 from ata_pipeline0.helpers.fields import FieldNew, FieldSnowplow
 from ata_pipeline0.helpers.preprocessors import (
     AddFieldFormSubmitIsNewsletter,
@@ -41,13 +42,13 @@ class TestAddFieldFormSubmitIsNewsletter:
     def df(self, dummy_email) -> pd.DataFrame:
         df = pd.DataFrame(
             [
-                ["page_ping", None],
+                [EventName.PAGE_PING, None],
                 [
-                    "submit_form",
+                    EventName.SUBMIT_FORM,
                     "{'formId': '', 'formClasses': [], 'elements': [{'name': 'email', 'value': '%s', 'nodeName': 'INPUT', 'type': 'email'}]}"
                     % dummy_email,
                 ],
-                ["submit_form", "{'formId': '', 'formClasses': [], 'elements': []}"],
+                [EventName.SUBMIT_FORM, "{'formId': '', 'formClasses': [], 'elements': []}"],
             ],
             columns=[FieldSnowplow.EVENT_NAME, FieldSnowplow.SEMISTRUCT_FORM_SUBMIT],
         )
@@ -126,7 +127,7 @@ class TestConvertFieldTypes:
                     "1500",
                     None,
                     "2022-11-02T00:00:01.051Z",
-                    "page_ping",
+                    EventName.PAGE_PING,
                     None,
                 ],
                 [
@@ -134,7 +135,7 @@ class TestConvertFieldTypes:
                     None,
                     "400",
                     "2022-11-01T00:00:01.051Z",
-                    "submit_form",
+                    EventName.SUBMIT_FORM,
                     "{'field': 'value'}",
                 ],
                 [
@@ -142,7 +143,7 @@ class TestConvertFieldTypes:
                     "2000",
                     "200",
                     "2022-12-01T00:00:01.051Z",
-                    "focus_form",
+                    EventName.FOCUS_FORM,
                     None,
                 ],
                 [
@@ -319,21 +320,21 @@ class TestDeleteRowsEmpty:
                     "1500",
                     None,
                     "2022-11-02T00:00:01.051Z",
-                    "page_ping",
+                    EventName.PAGE_PING,
                 ],
                 [
                     "1",
                     None,
                     "400",
                     "2022-11-01T00:00:01.051Z",
-                    "submit_form",
+                    EventName.SUBMIT_FORM,
                 ],
                 [
                     "2",
                     "2000",
                     "200",
                     "2022-12-01T00:00:01.051Z",
-                    "focus_form",
+                    EventName.FOCUS_FORM,
                 ],
                 [
                     "1",
@@ -376,7 +377,7 @@ class TestReplaceNaNs:
     @pytest.fixture(scope="class")
     def df(self) -> pd.DataFrame:
         return pd.DataFrame(
-            [[np.nan, "page_ping"], [np.nan, np.nan]], columns=[FieldSnowplow.EVENT_ID, FieldSnowplow.EVENT_NAME]
+            [[np.nan, EventName.PAGE_PING], [np.nan, np.nan]], columns=[FieldSnowplow.EVENT_ID, FieldSnowplow.EVENT_NAME]
         )
 
     @pytest.fixture(scope="class")
@@ -403,7 +404,7 @@ class TestSelectFieldsRelevant:
             [
                 [
                     "2022-11-02T00:00:01.051Z",
-                    "page_ping",
+                    EventName.PAGE_PING,
                     None,
                 ]
             ],

--- a/tests/site/test_newsletter.py
+++ b/tests/site/test_newsletter.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 
+from ata_pipeline0.helpers.events import EventName
 from ata_pipeline0.helpers.fields import FieldSnowplow
 from ata_pipeline0.site.names import SiteName
 from ata_pipeline0.site.newsletter import (
@@ -31,7 +32,7 @@ class TestSite:
                     "768",
                     "1366",
                     "2bba4051-c7f9-46cd-90bc-9b869a5fe187",
-                    "submit_form",
+                    EventName.SUBMIT_FORM,
                     "156f6713-4722-49cc-8335-721742f66525",
                     "https://www.afrolanews.org/",
                     "/subscribe",
@@ -103,7 +104,7 @@ class TestAfroLa:
                     "768",
                     "1366",
                     "2bba4051-c7f9-46cd-90bc-9b869a5fe187",
-                    "submit_form",
+                    EventName.SUBMIT_FORM,
                     "156f6713-4722-49cc-8335-721742f66525",
                     "https://www.afrolanews.org/",
                     "/subscribe",
@@ -156,7 +157,7 @@ class TestDallasFreePress:
                     "800",
                     "1280",
                     "8c62f083-539a-4158-bddd-ec83271639cd",
-                    "submit_form",
+                    EventName.SUBMIT_FORM,
                     "957e4dc1-2754-4213-949b-d5928d446911",
                     "https://dallasfreepress.com/dallas-news/dallas-forgot-remember-reclaim-lost-black-schools-education-history/",
                     "/text-and-email-notifications/",
@@ -220,7 +221,7 @@ class TestOpenVallejoNewsletterSignupValidators:
                     "693",
                     "320",
                     "dc2295e6-7e64-4f17-9df3-53466045eac9",
-                    "submit_form",
+                    EventName.SUBMIT_FORM,
                     "173295ed-93ac-4504-8dd8-d880f8d2c74e",
                     "https://openvallejo.org/donate/?mc_cid=396eb8ce49&mc_eid=3327a7bf29&utm_campaign=396eb8ce49-Vallejo+patrol+staffing+story_COPY_01&utm_medium=email&utm_source=Open+Vallejo&utm_term=0_5c634b5220-396eb8ce49-600953573",
                     "/newsletter/",
@@ -297,7 +298,7 @@ class TestThe19thNewsletterSignupValidators:
                     "1024",
                     "768",
                     "4d768aef-addc-4a3a-a133-1ea7fbd184f1",
-                    "submit_form",
+                    EventName.SUBMIT_FORM,
                     "b800111b-fe37-4f49-b0c9-61fbbcc5ff4a",
                     "https://www.google.com/",
                     "/2022/06/mayra-flores-record-women-congress/",

--- a/tests/test_write_events.py
+++ b/tests/test_write_events.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
+from ata_pipeline0.helpers.events import EventName
 from ata_pipeline0.helpers.fields import FieldNew, FieldSnowplow
 from ata_pipeline0.site.names import SiteName
 from ata_pipeline0.write_events import write_events
@@ -30,7 +31,7 @@ def df(all_fields, preprocessor_convert_all_field_types) -> pd.DataFrame:
                 "736.0",
                 "414.0",
                 "3784c768-0eaf-407e-ac35-baa285bfba53",
-                "page_ping",
+                EventName.PAGE_PING,
                 "47a36759-7b59-4171-8db2-59fdbb0cde9a",
                 "https://duckduckgo.com/",
                 "/author/Diante-Marigny/",
@@ -51,7 +52,7 @@ def df(all_fields, preprocessor_convert_all_field_types) -> pd.DataFrame:
                 "600.0",
                 "800.0",
                 "74309984-1b10-445a-9b1a-e05ee448abd9",
-                "page_view",
+                EventName.PAGE_VIEW,
                 "70366c22-fff7-4ce1-8242-d7367a51dae7",
                 None,
                 "/west-dallas/west-dallas-history-environmental-injustice-timeline-concrete/",
@@ -72,7 +73,7 @@ def df(all_fields, preprocessor_convert_all_field_types) -> pd.DataFrame:
                 "900.0",
                 "1440.0",
                 "95d7ea22-76f9-4f34-8c6c-9197cbb4e9d4",
-                "submit_form",
+                EventName.SUBMIT_FORM,
                 "00ffcb05-8fe9-46b2-8c7f-0556012d617d",
                 None,
                 "/",


### PR DESCRIPTION
## Description

The `Event` enum, which holds different event names, was created in #24. This PR changes parts of the code to use this enum and renames it to `EventName` to prevent conflict with the `Event` SQLModel class in the `ata-db-models`.

## Testing

All tests passed.