### PR TITLE
Fix fetch-event bug caused by empty list of DataFrames

### DIFF
--- a/ata_pipeline0/fetch_events.py
+++ b/ata_pipeline0/fetch_events.py
@@ -55,7 +55,10 @@ def fetch_events(
     with ThreadPoolExecutor(max_workers=num_concurrent_downloads) as executor:
         dfs = executor.map(_fetch_decompress_parse, object_summaries)
 
-    df = pd.concat(dfs)
+    # Append an empty DataFrame at the beginning in case len(dfs) == 0, in which
+    # case using dfs alone causes pd.concat throws an error
+    df = pd.concat([pd.DataFrame(), *dfs])
+
     logger.info(f"Fetched DataFrame shape: {df.shape}")
 
     return df


### PR DESCRIPTION
## Description

Fixes a bug in the event-fetching script caused by `pd.concat` erroring out upon empty DataFrame list.

## Testing

All tests passed.