### PR TITLE
Backfill fixups

### DIFF
--- a/ata_pipeline0/backfill.py
+++ b/ata_pipeline0/backfill.py
@@ -3,8 +3,11 @@ from datetime import datetime, timedelta
 import click
 
 from ata_pipeline0.helpers.datetime import get_timestamps
+from ata_pipeline0.helpers.logging import logging
 from ata_pipeline0.helpers.site import SiteName
 from ata_pipeline0.main import run_pipeline
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -15,11 +18,25 @@ from ata_pipeline0.main import run_pipeline
     help="Start date to run the backfill from.",
 )
 @click.option("--days", type=int, default=1, help="How many days of data to grab after the start date.")
+@click.option("--batch", is_flag=True, default=False, help="Set to batch runs per-timestamp; use for larger ranges.")
+@click.option("--batch-size", type=int, default=1, help="Number of hours to batch by.")
 @click.argument("site", type=SiteName)
-def backfill(start_date: datetime, days: int, site: SiteName):
+def backfill(start_date: datetime, days: int, batch: bool, batch_size: int, site: SiteName):
+    exec_start = datetime.now()
     timestamps = get_timestamps(start_date=start_date, days=days)
     # call function that calls the whole process; handler should call the same fn
-    run_pipeline(site_name=site, timestamps=timestamps)
+    if batch:
+        for batch_num, idx in enumerate(range(0, len(timestamps), batch_size)):
+            current_timestamps = timestamps[idx : idx + batch_size]
+            logger.info(f"Running batch #{batch_num} for the following timestamps:")
+            for ts in current_timestamps:
+                logger.info(f"--> {ts}")
+            run_pipeline(site_name=site, timestamps=current_timestamps)
+    else:
+        run_pipeline(site_name=site, timestamps=timestamps)
+    exec_end = datetime.now()
+    exec_total = exec_end - exec_start
+    logger.info(f"Backfill finished, took: {exec_total} long.")
 
 
 if __name__ == "__main__":

--- a/ata_pipeline0/fetch_events.py
+++ b/ata_pipeline0/fetch_events.py
@@ -55,7 +55,10 @@ def fetch_events(
     with ThreadPoolExecutor(max_workers=num_concurrent_downloads) as executor:
         dfs = executor.map(_fetch_decompress_parse, object_summaries)
 
-    df = pd.concat(dfs)
+    try:
+        df = pd.concat(dfs)
+    except ValueError:
+        df = pd.DataFrame()
     logger.info(f"Fetched DataFrame shape: {df.shape}")
 
     return df

--- a/ata_pipeline0/write_events.py
+++ b/ata_pipeline0/write_events.py
@@ -18,25 +18,30 @@ def write_events(df: pd.DataFrame, session_factory: sessionmaker) -> int:
     """
     data = df.to_dict(orient="records")
 
-    # Create statement to bulk-insert event rows
-    # Insert.on_conflict_do_nothing skips through events whose [event_id, site_name]
-    # composite key already exists in the DB
-    statement = insert(Event).values(data).on_conflict_do_nothing(index_elements=[Event.site_name, Event.event_id])
+    if data:
 
-    # Wrap execution within a begin-commit-rollback block
-    # (see: https://docs.sqlalchemy.org/en/14/orm/session_basics.html#framing-out-a-begin-commit-rollback-block)
-    # TODO: Once sqlalchemy-stubs catches up to SQLAlchemy 1.4, remove the type: ignore comment below
-    # (see: https://github.com/dropbox/sqlalchemy-stubs/blob/ed9611114925f4b2aea42401217c0eacb1a564e1/sqlalchemy-stubs/orm/session.pyi#L102)
-    with session_factory.begin() as session:  # type: ignore
-        result = session.execute(statement)
+        # Create statement to bulk-insert event rows
+        # Insert.on_conflict_do_nothing skips through events whose [event_id, site_name]
+        # composite key already exists in the DB
+        statement = insert(Event).values(data).on_conflict_do_nothing(index_elements=[Event.site_name, Event.event_id])
 
-    # Count number of rows/events inserted
-    num_rows_inserted = result.rowcount
+        # Wrap execution within a begin-commit-rollback block
+        # (see: https://docs.sqlalchemy.org/en/14/orm/session_basics.html#framing-out-a-begin-commit-rollback-block)
+        # TODO: Once sqlalchemy-stubs catches up to SQLAlchemy 1.4, remove the type: ignore comment below
+        # (see: https://github.com/dropbox/sqlalchemy-stubs/blob/ed9611114925f4b2aea42401217c0eacb1a564e1/sqlalchemy-stubs/orm/session.pyi#L102)
+        with session_factory.begin() as session:  # type: ignore
+            result = session.execute(statement)
 
-    # Log message
-    logger.info(
-        f"Inserted {num_rows_inserted} rows into the {Event.__name__} table. "
-        + f"Skipped {df.shape[0] - num_rows_inserted} rows whose event ID-site name composite key already exists."
-    )
+        # Count number of rows/events inserted
+        num_rows_inserted = result.rowcount
 
-    return num_rows_inserted
+        # Log message
+        logger.info(
+            f"Inserted {num_rows_inserted} rows into the {Event.__name__} table. "
+            + f"Skipped {df.shape[0] - num_rows_inserted} rows whose event ID-site name composite key already exists."
+        )
+
+        return num_rows_inserted
+    else:
+        logger.info("No rows to insert.")
+        return 0


### PR DESCRIPTION
- adds `batch` and `batch-size` options to backfill run parameters
- implements a timestamp-based batching process; this is useful if there is a lot of data to grab and the machine running the process doesn't have enough memory to hold it all at once
- adds a `_safe_bot_check` method to wrap the user agent bot check in a `try`/`except` block in case the user agent is not a string
- checks if there is any data to write before writing it; if not, it skips the process, logs it as such, and returns 0